### PR TITLE
Add support for running on mybinder.org

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - defaults
+dependencies:
+  - matplotlib
+  - pandas
+  - xlrd


### PR DESCRIPTION
Adds an `environment.yml` file so this repo can be run on https://mybinder.org/

For example, load the repo in mybinder: https://mybinder.org/v2/gh/manics/Covid19-Data-Personal/master
Or to go straight to the notebook: https://mybinder.org/v2/gh/manics/Covid19-Data-Personal/master?filepath=England_Covid19_Deaths_Datawrangling.ipynb

If you add a README you could also add a badge, for example
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/manics/Covid19-Data-Personal/master?filepath=England_Covid19_Deaths_Datawrangling.ipynb)

`[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/manics/Covid19-Data-Personal/master?filepath=England_Covid19_Deaths_Datawrangling.ipynb)`

Obviously change `manics` to `jamespjh`
